### PR TITLE
[VR-53] Minor: Change method name and remove setter

### DIFF
--- a/src/main/java/com/vroomvroom/safemobis/controller/MemberController.java
+++ b/src/main/java/com/vroomvroom/safemobis/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.vroomvroom.safemobis.controller;
 
 import com.vroomvroom.safemobis.domain.Member;
 import com.vroomvroom.safemobis.domain.Path;
-import com.vroomvroom.safemobis.domain.TrafficMode;
 import com.vroomvroom.safemobis.domain.enumerate.TrafficCode;
 import com.vroomvroom.safemobis.domain.enumerate.WarningCode;
 import com.vroomvroom.safemobis.dto.request.member.*;
@@ -21,9 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.vroomvroom.safemobis.domain.enumerate.TrafficCode.CAR;
 import static com.vroomvroom.safemobis.security.SecurityUtil.getCurrentUsername;
@@ -64,32 +61,31 @@ public class MemberController {
     }
 
     @PatchMapping ("/traffic-code")
-    public ResponseEntity<BaseResponse> setTrafficcode(@Valid @RequestBody MembersTrafficCodePatchRequestDto membersTrafficCodePatchRequestDto, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse> updateTrafficCode(@Valid @RequestBody MembersTrafficCodePatchRequestDto membersTrafficCodePatchRequestDto, HttpServletRequest request) {
         TrafficCode trafficCode = membersTrafficCodePatchRequestDto.getTrafficCode();
-        memberService.setTrafficCode(trafficCode);
+        memberService.updateTrafficCode(trafficCode);
         return new ResponseEntity<>(BaseResponse.of(request, OK.value()), OK);
     }
 
     @GetMapping("/traffic-code")
-    public ResponseEntity<BaseResponse> getTrafficcode(HttpServletRequest request) {
+    public ResponseEntity<BaseResponse> getTrafficCode(HttpServletRequest request) {
         MembersTrafficCodeGetResponseDto membersTrafficCodeGetResponseDto = memberService.getTrafficCode();
         return new ResponseEntity<>(BaseResponse.of(request, OK.value(), membersTrafficCodeGetResponseDto), OK);
     }
 
     @PatchMapping("/traffic-mode")
-    public ResponseEntity<BaseResponse> setTrafficmode(@Valid @RequestBody MembersTrafficModePatchRequestDto membersTrafficModePatchRequestDto, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse> updateTrafficMode(@Valid @RequestBody MembersTrafficModePatchRequestDto membersTrafficModePatchRequestDto, HttpServletRequest request) {
         List<MembersTrafficModeRequestDto> membersTrafficModeRequestDtos = membersTrafficModePatchRequestDto.getTrafficMode();
-        memberService.setTrafficMode(membersTrafficModeRequestDtos);
+        memberService.updateTrafficMode(membersTrafficModeRequestDtos);
         return new ResponseEntity<>(BaseResponse.of(request, OK.value()), OK);
     }
 
-
     @GetMapping("/traffic-mode")
-    private ResponseEntity<BaseResponse> getTrafficmode(HttpServletRequest request) {
-        List<MembersTrafficModeResponseDto> membersTrafficModeResponseDtos = memberService.getTrafficMode();
+    private ResponseEntity<BaseResponse> getTrafficModes(HttpServletRequest request) {
+        List<MembersTrafficModeResponseDto> membersTrafficModeResponseDtos = memberService.getTrafficModes();
         MembersTrafficModeGetResponseDto membersTrafficModeGetResponseDto = MembersTrafficModeGetResponseDto.from(membersTrafficModeResponseDtos);
         return new ResponseEntity<>(BaseResponse.of(request, OK.value(), membersTrafficModeGetResponseDto), OK);
-     }
+    }
 
     @PostMapping("/path")
     public ResponseEntity<BaseResponse> savePath(@Valid @RequestBody MembersPathPostRequestDto membersPathPostRequestDto, HttpServletRequest request) {

--- a/src/main/java/com/vroomvroom/safemobis/domain/Member.java
+++ b/src/main/java/com/vroomvroom/safemobis/domain/Member.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import static java.lang.Boolean.TRUE;
 
 @Builder
-@Getter @Setter
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
@@ -92,4 +92,7 @@ public class Member extends BaseEntity implements UserDetails {
         }
     }
 
+    public void updateTrafficCode(TrafficCode trafficCode) {
+        this.trafficCode = trafficCode;
+    }
 }

--- a/src/main/java/com/vroomvroom/safemobis/domain/TrafficMode.java
+++ b/src/main/java/com/vroomvroom/safemobis/domain/TrafficMode.java
@@ -1,13 +1,14 @@
 package com.vroomvroom.safemobis.domain;
 
 import com.vroomvroom.safemobis.domain.enumerate.TrafficCode;
+import com.vroomvroom.safemobis.dto.request.member.format.MembersTrafficModeRequestDto;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 
 @Builder
-@Getter @Setter
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
@@ -45,4 +46,12 @@ public class TrafficMode extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    public void updateWarningFlag(MembersTrafficModeRequestDto m) {
+        carFlag = m.isCarFlag();
+        pedestrianFlag = m.isPedestrianFlag();
+        childFlag = m.isChildFlag();
+        kickBoardFlag = m.isKickBoardFlag();
+        bicycleFlag = m.isBicycleFlag();
+        motorcycleFlag = m.isMotorcycleFlag();
+    }
 }

--- a/src/main/java/com/vroomvroom/safemobis/dto/request/member/format/MembersTrafficModeRequestDto.java
+++ b/src/main/java/com/vroomvroom/safemobis/dto/request/member/format/MembersTrafficModeRequestDto.java
@@ -24,7 +24,7 @@ public class MembersTrafficModeRequestDto {
     private boolean childFlag;
 
     @NotNull
-    private boolean kickboardFlag;
+    private boolean kickBoardFlag;
 
     @NotNull
     private boolean motorcycleFlag;

--- a/src/main/java/com/vroomvroom/safemobis/service/MemberService.java
+++ b/src/main/java/com/vroomvroom/safemobis/service/MemberService.java
@@ -68,9 +68,9 @@ public class MemberService {
     }
 
     @Transactional
-    public void setTrafficCode(TrafficCode trafficCode) {
+    public void updateTrafficCode(TrafficCode trafficCode) {
         Member member = findByUsername(getCurrentUsername());
-        member.setTrafficCode(trafficCode);
+        member.updateTrafficCode(trafficCode);
     }
 
     public MembersTrafficCodeGetResponseDto getTrafficCode() {
@@ -79,26 +79,20 @@ public class MemberService {
     }
 
     @Transactional
-    public void setTrafficMode(List<MembersTrafficModeRequestDto> membersTrafficModeRequestDtos) {
+    public void updateTrafficMode(List<MembersTrafficModeRequestDto> membersTrafficModeRequestDtos) {
         Member member = findByUsername(getCurrentUsername());
         Map<TrafficCode, TrafficMode> map = new HashMap<>();
         for (TrafficMode t: member.getTrafficModes()) {
             map.put(t.getTrafficCode(), t);
         }
-
         for (MembersTrafficModeRequestDto m: membersTrafficModeRequestDtos) {
             TrafficMode t = map.get(m.getTrafficCode());
-            t.setCarFlag(m.isCarFlag());
-            t.setPedestrianFlag(m.isPedestrianFlag());
-            t.setChildFlag(m.isChildFlag());
-            t.setKickBoardFlag(m.isKickboardFlag());
-            t.setBicycleFlag(m.isBicycleFlag());
-            t.setMotorcycleFlag(m.isMotorcycleFlag());
+            t.updateWarningFlag(m);
         }
     }
 
     @Transactional
-    public List<MembersTrafficModeResponseDto> getTrafficMode() {
+    public List<MembersTrafficModeResponseDto> getTrafficModes() {
         Member member = findByUsername(getCurrentUsername());
         List<TrafficMode> trafficModes = member.getTrafficModes();
         List<MembersTrafficModeResponseDto> membersTrafficModeResponseDtos = new ArrayList<>();
@@ -112,7 +106,6 @@ public class MemberService {
                     .bicycleFlag(t.isBicycleFlag())
                     .motorcycleFlag(t.isMotorcycleFlag())
                     .build();
-
             membersTrafficModeResponseDtos.add(m);
         }
         return membersTrafficModeResponseDtos;


### PR DESCRIPTION
1. 메서드 이름 변경 1-1. CamelCase로 변경
자바는 CamelCase를 많이 사용
setTrafficcode -> setTrafficCode
setTrafficmode -> setTrafficMode

2. setter 제거 -> 의미있는 메서드 이름으로 변경 2-1. 엔티티에서 setter 제거
엔티티에 @Setter는 보통 열어두지 않는다.
모든 필드 데이터 변경의 가능성을 열어두는 것이기 때문
2-2. 의미있는 이름으로 변경
setTrafficCode -> updateTrafficCode